### PR TITLE
Missing @Inject annotation

### DIFF
--- a/OpenUP/EPF-gateway/src/main/java/epf/gateway/Registry.java
+++ b/OpenUP/EPF-gateway/src/main/java/epf/gateway/Registry.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import javax.ws.rs.client.ClientBuilder;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import epf.naming.Naming;
@@ -26,6 +27,7 @@ public class Registry {
 	/**
 	 * 
 	 */
+	@Inject
 	@ConfigProperty(name = Naming.Registry.REGISTRY_URL)
 	String registryUrl;
     

--- a/OpenUP/EPF-shell/src/main/java/epf/shell/client/ClientUtil.java
+++ b/OpenUP/EPF-shell/src/main/java/epf/shell/client/ClientUtil.java
@@ -10,6 +10,8 @@ import java.net.URI;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
@@ -27,6 +29,7 @@ public class ClientUtil {
 	/**
 	 * 
 	 */
+	@Inject
 	@ConfigProperty(name = Naming.Client.CLIENT_CONFIG + "/mp-rest/uri")
 	URI gatewayUrl;
 

--- a/OpenUP/EPF-shell/src/main/java/epf/shell/security/Security.java
+++ b/OpenUP/EPF-shell/src/main/java/epf/shell/security/Security.java
@@ -60,6 +60,7 @@ public class Security {
 	/**
 	 * 
 	 */
+	@Inject
 	@ConfigProperty(name = Naming.Shell.SHELL_URL)
 	String shellUrl;
 


### PR DESCRIPTION
When using the `@ConfigProperty` annotation from Microprofile on a field, the field must be annotated with `@Inject`.